### PR TITLE
Add write-blog skill for bilingual technical blog posts

### DIFF
--- a/.claude/skills/write-blog/SKILL.md
+++ b/.claude/skills/write-blog/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: write-blog
+description: Write a new technical blog post for this portfolio. Use when asked to write, draft, or create a new blog article. Produces both en.mdx and ja.mdx with a personal, human-like writing style — no AI filler, no corporate buzzwords.
+---
+
+# Write Blog Skill
+
+このスキルはポートフォリオのブログに技術記事を書く。英語（en.mdx）と日本語（ja.mdx）の両方を作成する。
+
+## 最初にやること
+
+まず `.claude/skills/write-blog/avoid-phrases.md` を Read して、避けるべき表現のリストを把握する。記事全体を通してそのリストを守る。
+
+---
+
+## Blog System
+
+- **ファイルの場所**: `src/content/blog/{slug}/en.mdx` と `ja.mdx`
+- **slug ルール**: ケバブケース、英小文字と数字のみ（例: `debugging-swift-concurrency`）
+- **frontmatter**:
+  ```yaml
+  ---
+  title: "..."
+  date: "YYYY-MM-DD"
+  description: "..."
+  tags: ["...", "..."]
+  published: false
+  ---
+  ```
+- **フォーマット**: MDX（コードブロック、見出し、太字、リンク使用可）
+- `published: false` は変更しない。公開はユーザーが判断する。
+
+---
+
+## Step 1: 情報を集める
+
+以下をユーザーに確認する（まとめて質問してよい）:
+
+1. **トピック**: 何について書くか
+2. **実体験**: 具体的にどんなことをやったか。何でハマったか。どう解決したか
+3. **ターゲット読者**: 同じ技術を使う開発者? 初学者?
+4. **含めたいコード例**: あれば教えてもらう
+5. **slug の候補**: なければ提案する
+
+---
+
+## Step 2: 構成を提案する
+
+記事の見出し構成（H2 レベル）を提示し、ユーザーの確認を取る。承認されたら執筆に進む。
+
+---
+
+## Step 3: 執筆ガイドライン
+
+### 人間らしい文章を書くための原則
+
+**書き方の基本**
+- 一人称で書く（英: "I", 日: 「私は」「〜した」「〜だった」）
+- 一般論ではなく自分の経験を語る。「SwiftUI は便利だ」ではなく「SwiftUI に乗り換えて、状態管理で最初は混乱した」
+- 迷い、失敗、試行錯誤を書く。うまくいった話だけでは読者に響かない
+- 選択の理由を書く。「Next.js を選んだ」ではなく「UIKit でも書けたが、SwiftUI の宣言的な書き方が自分の思考に合っていた」
+- 具体的な数字、バージョン、プロジェクト名を使う
+
+**文体**
+- 短い文と長い文を混ぜる。リズムが生まれる
+- 文章の冒頭は毎回同じ形にしない（「〜は」「〜が」を交互に使うなど）
+- 英語: 口語的な短縮形を使ってよい（"I'd", "it's", "that's"）
+- 日本語: 「〜です」「〜ます」だけに揃えず、「〜した」「〜だった」も混ぜて自然なリズムを出す
+
+**締め方**
+- 「In conclusion」「まとめると」で始めない
+- 次にやりたいことや、まだ解決していない問いで終わるのが自然
+- 短くてよい。最後の段落は 2〜3 文で十分
+
+**避けること** (`avoid-phrases.md` を参照すること)
+
+---
+
+## Step 4: ファイルを作成する
+
+### 英語版 (en.mdx)
+
+```
+src/content/blog/{slug}/en.mdx
+```
+
+自然な英語で書く。日本語版の直訳にしない。英語として自然な表現を選ぶ。
+
+### 日本語版 (ja.mdx)
+
+```
+src/content/blog/{slug}/ja.mdx
+```
+
+英語版の構造・見出しに揃える。ただし英語の直訳ではなく、日本語として自然な表現を使う。
+コードブロックのコメントは日本語にする。
+
+---
+
+## 完了後
+
+ユーザーに以下を伝える:
+- 作成したファイルパス（en/ja 両方）
+- 記事を公開する場合は `published: false` → `true` に変更するよう案内する

--- a/.claude/skills/write-blog/SKILL.md
+++ b/.claude/skills/write-blog/SKILL.md
@@ -1,22 +1,44 @@
 ---
 name: write-blog
-description: Write a new technical blog post for this portfolio. Use when asked to write, draft, or create a new blog article. Produces both en.mdx and ja.mdx with a personal, human-like writing style — no AI filler, no corporate buzzwords.
+description: Write a new technical blog post for the portfolio. Works from ANY repository — useful for documenting problems or findings from another codebase as a portfolio blog article. Produces both en.mdx and ja.mdx with a personal, human-like writing style — no AI filler, no corporate buzzwords.
 ---
 
 # Write Blog Skill
 
 このスキルはポートフォリオのブログに技術記事を書く。英語（en.mdx）と日本語（ja.mdx）の両方を作成する。
+**別リポジトリから呼び出した場合でも動作する。** そのリポジトリで詰まったこと・学んだことをそのままブログ記事にできる。
 
-## 最初にやること
+---
 
-まず `.claude/skills/write-blog/avoid-phrases.md` を Read して、避けるべき表現のリストを把握する。記事全体を通してそのリストを守る。
+## Step 0: 準備
+
+### 0-1. Portfolio の場所を特定する
+
+```bash
+# 現在地がportfolioか確認
+ls src/content/blog/ 2>/dev/null && echo "IN_PORTFOLIO" || echo "NOT_IN_PORTFOLIO"
+```
+
+- `IN_PORTFOLIO` の場合: `PORTFOLIO_ROOT=.`
+- `NOT_IN_PORTFOLIO` の場合: 以下の順で探す
+  1. `ls ../portfolio/src/content/blog/ 2>/dev/null`
+  2. `find /home -maxdepth 4 -type d -name "blog" -path "*/content/blog" 2>/dev/null | head -3`
+  3. 見つからなければユーザーに portfolio のパスを聞く
+
+### 0-2. 避けるべき表現リストを読む
+
+`{PORTFOLIO_ROOT}/.claude/skills/write-blog/avoid-phrases.md` を Read して把握する。記事全体を通してそのリストを守る。
+
+### 0-3. 別リポジトリから実行した場合の文脈整理
+
+現在のリポジトリ（`git remote get-url origin 2>/dev/null` で確認）をユーザーに伝え、**そのリポジトリでの体験や問題をブログに書く**ことを前提に進める。
 
 ---
 
 ## Blog System
 
-- **ファイルの場所**: `src/content/blog/{slug}/en.mdx` と `ja.mdx`
-- **slug ルール**: ケバブケース、英小文字と数字のみ（例: `debugging-swift-concurrency`）
+- **ファイルの場所**: `{PORTFOLIO_ROOT}/src/content/blog/{slug}/en.mdx` と `ja.mdx`
+- **slug ルール**: ケバブケース、英小文字・数字・ハイフン（`-`）のみ（例: `debugging-swift-concurrency`）
 - **frontmatter**:
   ```yaml
   ---
@@ -36,10 +58,10 @@ description: Write a new technical blog post for this portfolio. Use when asked 
 
 以下をユーザーに確認する（まとめて質問してよい）:
 
-1. **トピック**: 何について書くか
+1. **トピック**: 何について書くか（別リポジトリから呼んだ場合はそのリポジトリでの出来事が出発点になる）
 2. **実体験**: 具体的にどんなことをやったか。何でハマったか。どう解決したか
-3. **ターゲット読者**: 同じ技術を使う開発者? 初学者?
-4. **含めたいコード例**: あれば教えてもらう
+3. **ターゲット読者**: 同じ技術を使う開発者？ 初学者？
+4. **含めたいコード例**: あれば教えてもらう（別リポジトリのコードを参照してよい）
 5. **slug の候補**: なければ提案する
 
 ---
@@ -55,15 +77,15 @@ description: Write a new technical blog post for this portfolio. Use when asked 
 ### 人間らしい文章を書くための原則
 
 **書き方の基本**
-- 一人称で書く（英: "I", 日: 「私は」「〜した」「〜だった」）
-- 一般論ではなく自分の経験を語る。「SwiftUI は便利だ」ではなく「SwiftUI に乗り換えて、状態管理で最初は混乱した」
+- 一人称で書く（英: "I", 日: 「〜した」「〜だった」）
+- 一般論ではなく自分の経験を語る
 - 迷い、失敗、試行錯誤を書く。うまくいった話だけでは読者に響かない
-- 選択の理由を書く。「Next.js を選んだ」ではなく「UIKit でも書けたが、SwiftUI の宣言的な書き方が自分の思考に合っていた」
-- 具体的な数字、バージョン、プロジェクト名を使う
+- 選択の理由を書く。「〇〇を使った」ではなく「〇〇と△△で迷って、〇〇にした理由は〜だった」
+- 具体的な数字、バージョン、プロジェクト名、エラーメッセージを使う
 
 **文体**
 - 短い文と長い文を混ぜる。リズムが生まれる
-- 文章の冒頭は毎回同じ形にしない（「〜は」「〜が」を交互に使うなど）
+- 文章の冒頭は毎回同じ形にしない
 - 英語: 口語的な短縮形を使ってよい（"I'd", "it's", "that's"）
 - 日本語: 「〜です」「〜ます」だけに揃えず、「〜した」「〜だった」も混ぜて自然なリズムを出す
 
@@ -72,24 +94,24 @@ description: Write a new technical blog post for this portfolio. Use when asked 
 - 次にやりたいことや、まだ解決していない問いで終わるのが自然
 - 短くてよい。最後の段落は 2〜3 文で十分
 
-**避けること** (`avoid-phrases.md` を参照すること)
+**避けること** (Step 0-2 で読んだ `avoid-phrases.md` を参照)
 
 ---
 
 ## Step 4: ファイルを作成する
 
-### 英語版 (en.mdx)
+### 英語版
 
 ```
-src/content/blog/{slug}/en.mdx
+{PORTFOLIO_ROOT}/src/content/blog/{slug}/en.mdx
 ```
 
 自然な英語で書く。日本語版の直訳にしない。英語として自然な表現を選ぶ。
 
-### 日本語版 (ja.mdx)
+### 日本語版
 
 ```
-src/content/blog/{slug}/ja.mdx
+{PORTFOLIO_ROOT}/src/content/blog/{slug}/ja.mdx
 ```
 
 英語版の構造・見出しに揃える。ただし英語の直訳ではなく、日本語として自然な表現を使う。
@@ -102,3 +124,4 @@ src/content/blog/{slug}/ja.mdx
 ユーザーに以下を伝える:
 - 作成したファイルパス（en/ja 両方）
 - 記事を公開する場合は `published: false` → `true` に変更するよう案内する
+- 別リポジトリから実行した場合: portfolio でコミット・プッシュが必要なことを伝える

--- a/.claude/skills/write-blog/avoid-phrases.md
+++ b/.claude/skills/write-blog/avoid-phrases.md
@@ -1,0 +1,89 @@
+# 避けるべき表現リスト / Phrases to Avoid
+
+このファイルは自由に編集できます。記事を書く前に必ず参照してください。
+
+---
+
+## English
+
+### Filler openers
+- "It's worth noting that..."
+- "It is important to note that..."
+- "Notably,"
+- "Importantly,"
+- "Certainly!"
+- "Absolutely!"
+- "Great question!"
+- "Of course!"
+
+### Weak conclusions
+- "In conclusion,"
+- "In summary,"
+- "To summarize,"
+- "To wrap up,"
+- "All in all,"
+- "At the end of the day,"
+
+### Vague academic-sounding phrases
+- "Delve into"
+- "Furthermore,"
+- "Moreover,"
+- "In the realm of"
+- "In the landscape of"
+- "In today's fast-paced world"
+- "The world of [tech]"
+
+### Corporate buzzwords
+- "Leverage" (use "use" instead)
+- "Utilize" (use "use" instead)
+- "Facilitate"
+- "Streamline"
+- "Robust"
+- "Seamlessly"
+- "Cutting-edge"
+- "State-of-the-art"
+- "Best practices"
+- "Game-changer"
+- "Revolutionize"
+
+### Hedging AI-isms
+- "It's important to remember that..."
+- "Keep in mind that..."
+- "As you may know,"
+- "I hope this helps"
+- "Feel free to..."
+
+---
+
+## 日本語
+
+### 文末の曖昧な表現
+- 〜といえるでしょう
+- 〜ではないでしょうか
+- 〜かもしれません（多用は NG）
+- 〜と考えられます
+- 〜と思われます
+
+### 回りくどい書き方
+- 〜することができます → 〜できます
+- 〜を行うことができます → 〜できます / 〜します
+- 〜という点に注意が必要です
+- 〜する必要があります（多用は NG）
+- 〜において
+
+### AI 的な結論表現
+- まとめると、
+- 結論として、
+- 以上のことから、
+- 総じて、
+- 振り返ってみると、（締めの定型文として使うとき）
+
+### 大げさ・空虚なビジネス語
+- 〜を活用する（単に「使う」でよい場合）
+- 〜を実現する（多用は NG）
+- 〜を提供する（多用は NG）
+- 〜を推進する
+- 革新的な
+- 強力な（powerful の直訳）
+- シームレスに
+- ベストプラクティス


### PR DESCRIPTION
## Summary

- `portfolio/.claude/skills/write-blog/SKILL.md` を追加 — ブログ記事（en/ja MDX）を書くための Claude Code プロジェクトスキル
- `portfolio/.claude/skills/write-blog/avoid-phrases.md` を追加 — AI 感のある表現・使いたくない言い回しの編集可能リスト

## What this skill does

`/write-blog` で呼び出すと Claude が:
1. トピック・実体験・含めたいコード例をユーザーに確認
2. 構成（見出し）を提案して承認を取る
3. `src/content/blog/{slug}/en.mdx` と `ja.mdx` を作成
4. `avoid-phrases.md` を参照しながら、AI 的な常套句を避けた人間味のある文章で執筆

## Test plan

- [ ] `portfolio` プロジェクトで `/write-blog` を呼び出し、スキルが起動することを確認
- [ ] トピックを与えて `src/content/blog/` に en.mdx と ja.mdx が生成されることを確認
- [ ] `bun run build` がエラーなく通ること（frontmatter の形式確認）
- [ ] 生成された文章に `avoid-phrases.md` の表現が含まれないことを確認

https://claude.ai/code/session_016YQcNVBVFSThXjxy9SWKKg

---
_Generated by [Claude Code](https://claude.ai/code/session_016YQcNVBVFSThXjxy9SWKKg)_