### PR TITLE
Fetch blog content from portal API (Obsidian/blogs)

### DIFF
--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -17,18 +17,23 @@ type Params = AsyncLangParam & {
 	params: Promise<{ lang: "en" | "ja"; slug: string }>;
 };
 
-export const dynamicParams = false;
+export const revalidate = 3600;
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
 	const langs = ["en", "ja"] as const;
-	return langs.flatMap((lang) =>
-		getAllPosts(lang).map((post) => ({ lang, slug: post.slug })),
+	const results = await Promise.all(
+		langs.map(async (lang) => {
+			const posts = await getAllPosts(lang);
+			return posts.map((post) => ({ lang, slug: post.slug }));
+		}),
 	);
+	return results.flat();
 }
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
 	const { lang, slug } = await params;
-	const post = getPost(slug, lang);
+	const post = await getPost(slug, lang);
 	if (!post?.published) return {};
 	return {
 		title: post.title,
@@ -52,7 +57,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 
 const BlogPost = async ({ params }: Params) => {
 	const { lang, slug } = await params;
-	const post = getPost(slug, lang);
+	const post = await getPost(slug, lang);
 	if (!post?.published) notFound();
 
 	const dict = await getDictionary(lang);

--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 const BlogPost = async ({ params }: Params) => {
 	const { lang, slug } = await params;
 	const post = await getPost(slug, lang);
-	if (!post?.published) notFound();
+	if (!post || !post.published) notFound();
 
 	const dict = await getDictionary(lang);
 

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -5,6 +5,8 @@ import type { AsyncLangParam } from "@/types/lang-param";
 import { getAllPosts } from "@/utils/blog";
 import { getDictionary } from "../dictionaries";
 
+export const revalidate = 3600;
+
 export async function generateMetadata({
 	params,
 }: AsyncLangParam): Promise<Metadata> {
@@ -28,7 +30,7 @@ export async function generateMetadata({
 const BlogList = async ({ params }: AsyncLangParam) => {
 	const { lang } = await params;
 	const dict = await getDictionary(lang);
-	const posts = getAllPosts(lang);
+	const posts = await getAllPosts(lang);
 
 	return (
 		<Wrapper>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -51,7 +51,8 @@ export default async function RootLayout({
 }>) {
 	const { lang } = await params;
 
-	const showBlog = getAllPosts(lang).length > 0;
+	const posts = await getAllPosts(lang);
+	const showBlog = posts.length > 0;
 	const navbar = <Header lang={lang} showBlog={showBlog} />;
 	const footer = <Footer />;
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,7 +8,7 @@ const langs = ["en", "ja"] as const;
 
 const staticRoutes = ["", "/blog", "/experiences", "/services"];
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const staticEntries: MetadataRoute.Sitemap = staticRoutes.flatMap((route) =>
 		langs.map((lang) => ({
 			url: `${BASE_URL}/${lang}${route}`,
@@ -17,10 +17,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		})),
 	);
 
-	// Use getAllPosts (published only) and deduplicate slugs across langs
+	const [enPosts, jaPosts] = await Promise.all([
+		getAllPosts("en"),
+		getAllPosts("ja"),
+	]);
+
 	const publishedSlugs = new Set([
-		...getAllPosts("en").map((p) => p.slug),
-		...getAllPosts("ja").map((p) => p.slug),
+		...enPosts.map((p) => p.slug),
+		...jaPosts.map((p) => p.slug),
 	]);
 
 	const blogEntries: MetadataRoute.Sitemap = [...publishedSlugs].flatMap(

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -35,20 +35,24 @@ function normalizeTags(raw: unknown): string[] {
 }
 
 export async function getAllPosts(lang: string): Promise<BlogPost[]> {
-	const posts = await apiFetch<Record<string, unknown>[]>(
-		`/api/blog?lang=${lang}`,
-	);
-	return posts
-		.map((raw) => ({
-			slug: String(raw.slug ?? ""),
-			title: String(raw.title ?? raw.slug ?? ""),
-			date: String(raw.date ?? ""),
-			description: String(raw.description ?? ""),
-			tags: normalizeTags(raw.tags),
-			image: typeof raw.image === "string" ? raw.image : undefined,
-			published: raw.published !== false,
-		}))
-		.filter((p) => p.published);
+	try {
+		const posts = await apiFetch<Record<string, unknown>[]>(
+			`/api/blog?lang=${lang}`,
+		);
+		return posts
+			.map((raw) => ({
+				slug: String(raw.slug ?? ""),
+				title: String(raw.title ?? raw.slug ?? ""),
+				date: String(raw.date ?? ""),
+				description: String(raw.description ?? ""),
+				tags: normalizeTags(raw.tags),
+				image: typeof raw.image === "string" ? raw.image : undefined,
+				published: raw.published !== false,
+			}))
+			.filter((p) => p.published);
+	} catch {
+		return [];
+	}
 }
 
 export async function getPost(

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,7 +1,4 @@
 import "server-only";
-import fs from "node:fs";
-import path from "node:path";
-import matter from "gray-matter";
 
 export type BlogPost = {
 	slug: string;
@@ -17,76 +14,62 @@ export type BlogPostWithContent = BlogPost & {
 	content: string;
 };
 
-const BLOG_DIR = path.join(process.cwd(), "src/content/blog");
-const VALID_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const VALID_LANG = new Set(["en", "ja"]);
+const BLOG_API_URL = process.env.BLOG_API_URL;
+const BLOG_API_KEY = process.env.BLOG_API_KEY;
 
-function safeMdxPath(slug: string, lang: string): string | null {
-	if (!VALID_SLUG.test(slug) || !VALID_LANG.has(lang)) return null;
-
-	const preferred = path.resolve(BLOG_DIR, slug, `${lang}.mdx`);
-	const fallback = path.resolve(BLOG_DIR, slug, "en.mdx");
-
-	if (!preferred.startsWith(BLOG_DIR + path.sep)) return null;
-
-	return fs.existsSync(preferred) ? preferred : fallback;
+async function apiFetch<T>(path: string): Promise<T> {
+	if (!BLOG_API_URL || !BLOG_API_KEY) {
+		throw new Error("BLOG_API_URL and BLOG_API_KEY must be set");
+	}
+	const res = await fetch(`${BLOG_API_URL}${path}`, {
+		headers: { Authorization: `Bearer ${BLOG_API_KEY}` },
+		next: { revalidate: 3600 },
+	});
+	if (!res.ok) throw new Error(`Blog API ${res.status}: ${path}`);
+	return res.json() as Promise<T>;
 }
 
-function parseTags(raw: unknown): string[] {
+function normalizeTags(raw: unknown): string[] {
 	if (Array.isArray(raw)) return raw.map(String);
 	return [];
 }
 
-export function getAllPostSlugs(): string[] {
-	if (!fs.existsSync(BLOG_DIR)) return [];
-	return fs
-		.readdirSync(BLOG_DIR)
-		.filter(
-			(name) =>
-				VALID_SLUG.test(name) &&
-				fs.statSync(path.join(BLOG_DIR, name)).isDirectory(),
-		);
+export async function getAllPosts(lang: string): Promise<BlogPost[]> {
+	const posts = await apiFetch<Record<string, unknown>[]>(
+		`/api/blog?lang=${lang}`,
+	);
+	return posts
+		.map((raw) => ({
+			slug: String(raw.slug ?? ""),
+			title: String(raw.title ?? raw.slug ?? ""),
+			date: String(raw.date ?? ""),
+			description: String(raw.description ?? ""),
+			tags: normalizeTags(raw.tags),
+			image: typeof raw.image === "string" ? raw.image : undefined,
+			published: raw.published !== false,
+		}))
+		.filter((p) => p.published);
 }
 
-export function getAllPosts(lang: string): BlogPost[] {
-	return getAllPostSlugs()
-		.map((slug): BlogPost | null => {
-			const filePath = safeMdxPath(slug, lang);
-			if (!filePath || !fs.existsSync(filePath)) return null;
-			const { data } = matter(fs.readFileSync(filePath, "utf-8"));
-			return {
-				slug,
-				title: data.title ?? slug,
-				date: data.date ?? "",
-				description: data.description ?? "",
-				tags: parseTags(data.tags),
-				image: typeof data.image === "string" ? data.image : undefined,
-				published: data.published !== false,
-			};
-		})
-		.filter((p): p is BlogPost => p !== null && p.published)
-		.sort((a, b) => {
-			if (a.date > b.date) return -1;
-			if (a.date < b.date) return 1;
-			return a.slug.localeCompare(b.slug);
-		});
-}
-
-export function getPost(
+export async function getPost(
 	slug: string,
 	lang: string,
-): BlogPostWithContent | null {
-	const filePath = safeMdxPath(slug, lang);
-	if (!filePath || !fs.existsSync(filePath)) return null;
-	const { data, content } = matter(fs.readFileSync(filePath, "utf-8"));
-	return {
-		slug,
-		title: data.title ?? slug,
-		date: data.date ?? "",
-		description: data.description ?? "",
-		tags: parseTags(data.tags),
-		image: typeof data.image === "string" ? data.image : undefined,
-		published: data.published !== false,
-		content,
-	};
+): Promise<BlogPostWithContent | null> {
+	try {
+		const raw = await apiFetch<Record<string, unknown>>(
+			`/api/blog/${slug}?lang=${lang}`,
+		);
+		return {
+			slug: String(raw.slug ?? slug),
+			title: String(raw.title ?? slug),
+			date: String(raw.date ?? ""),
+			description: String(raw.description ?? ""),
+			tags: normalizeTags(raw.tags),
+			image: typeof raw.image === "string" ? raw.image : undefined,
+			published: raw.published !== false,
+			content: String(raw.content ?? ""),
+		};
+	} catch {
+		return null;
+	}
 }


### PR DESCRIPTION
## Summary

- `src/utils/blog.ts` をローカル fs 読み込みから portal API へのフェッチに変更
- `BLOG_API_URL` / `BLOG_API_KEY` 環境変数で接続先を設定
- ISR (`revalidate = 3600`) に変更 — 1時間ごとに自動再検証
- `dynamicParams = true` — ビルド後に追加した記事も初回アクセス時に生成

## 新規環境変数（Vercel 等に追加が必要）

```
BLOG_API_URL=https://<your-tunnel>.trycloudflare.com
BLOG_API_KEY=<portal側と同じキー>
```

## Test plan

- [ ] `BLOG_API_URL` と `BLOG_API_KEY` を設定して `bun dev` で `/en/blog` が表示される
- [ ] 個別記事ページが MDX レンダリングされる
- [ ] portal を停止した状態でも ISR キャッシュからページが返される
- [ ] 新しい記事を Obsidian に追加後、最大1時間で blog に反映される

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTTZGTrmR3CF4TJUDQXGve)_