### PR TITLE
Add blog preview listing page

### DIFF
--- a/src/app/[lang]/blog/preview/page.tsx
+++ b/src/app/[lang]/blog/preview/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import Wrapper from "@/components/custom/wrapper";
+import type { AsyncLangParam } from "@/types/lang-param";
+import { getAllPostsIncludingDrafts } from "@/utils/blog";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata() {
+	return { robots: { index: false, follow: false } };
+}
+
+const BlogPreviewList = async ({ params }: AsyncLangParam) => {
+	const { lang } = await params;
+	const posts = await getAllPostsIncludingDrafts(lang);
+
+	const published = posts.filter((p) => p.published);
+	const drafts = posts.filter((p) => !p.published);
+
+	const sectionStyle = {
+		marginBottom: "48px",
+	};
+
+	const headingStyle = {
+		fontSize: "0.75rem",
+		fontWeight: 600,
+		letterSpacing: "0.08em",
+		textTransform: "uppercase" as const,
+		opacity: 0.4,
+		marginBottom: "16px",
+	};
+
+	const listStyle = {
+		display: "flex",
+		flexDirection: "column" as const,
+		gap: "12px",
+	};
+
+	const itemStyle = (isDraft: boolean) => ({
+		display: "flex",
+		flexDirection: "column" as const,
+		gap: "4px",
+		padding: "12px 16px",
+		borderRadius: "8px",
+		background: isDraft ? "rgba(255, 200, 0, 0.06)" : "rgba(128,128,128,0.06)",
+		border: isDraft ? "1px solid rgba(255, 200, 0, 0.2)" : "1px solid rgba(128,128,128,0.12)",
+		textDecoration: "none",
+		color: "inherit",
+	});
+
+	const titleStyle = {
+		fontSize: "0.95rem",
+		fontWeight: 500,
+	};
+
+	const metaStyle = {
+		fontSize: "0.75rem",
+		opacity: 0.4,
+		fontFamily: "var(--font-geist-mono)",
+	};
+
+	return (
+		<Wrapper>
+			<h1
+				style={{
+					fontSize: "1.5rem",
+					fontWeight: 700,
+					marginBottom: "40px",
+					letterSpacing: "-0.02em",
+				}}
+			>
+				Blog Preview
+			</h1>
+
+			{drafts.length > 0 && (
+				<div style={sectionStyle}>
+					<p style={headingStyle}>Drafts ({drafts.length})</p>
+					<div style={listStyle}>
+						{drafts.map((post) => (
+							<Link
+								key={post.slug}
+								href={`/${lang}/blog/preview/${post.slug}`}
+								style={itemStyle(true)}
+							>
+								<span style={titleStyle}>{post.title}</span>
+								<span style={metaStyle}>{post.date || "no date"}</span>
+							</Link>
+						))}
+					</div>
+				</div>
+			)}
+
+			{published.length > 0 && (
+				<div style={sectionStyle}>
+					<p style={headingStyle}>Published ({published.length})</p>
+					<div style={listStyle}>
+						{published.map((post) => (
+							<Link
+								key={post.slug}
+								href={`/${lang}/blog/${post.slug}`}
+								style={itemStyle(false)}
+							>
+								<span style={titleStyle}>{post.title}</span>
+								<span style={metaStyle}>{post.date || "no date"}</span>
+							</Link>
+						))}
+					</div>
+				</div>
+			)}
+
+			{posts.length === 0 && (
+				<p style={{ opacity: 0.4, fontSize: "0.9rem" }}>No posts found.</p>
+			)}
+		</Wrapper>
+	);
+};
+
+export default BlogPreviewList;

--- a/src/app/[lang]/blog/preview/page.tsx
+++ b/src/app/[lang]/blog/preview/page.tsx
@@ -42,7 +42,9 @@ const BlogPreviewList = async ({ params }: AsyncLangParam) => {
 		padding: "12px 16px",
 		borderRadius: "8px",
 		background: isDraft ? "rgba(255, 200, 0, 0.06)" : "rgba(128,128,128,0.06)",
-		border: isDraft ? "1px solid rgba(255, 200, 0, 0.2)" : "1px solid rgba(128,128,128,0.12)",
+		border: isDraft
+			? "1px solid rgba(255, 200, 0, 0.2)"
+			: "1px solid rgba(128,128,128,0.12)",
 		textDecoration: "none",
 		color: "inherit",
 	});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,7 +39,7 @@ function getLocale(_request: NextRequest) {
 export function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
-	if (/^\/(en|ja)\/blog\/preview\//.test(pathname)) {
+	if (/^\/(en|ja)\/blog\/preview(\/|$)/.test(pathname)) {
 		const authResponse = requireBasicAuth(request);
 		if (authResponse) return authResponse;
 	}

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -55,6 +55,25 @@ export async function getAllPosts(lang: string): Promise<BlogPost[]> {
 	}
 }
 
+export async function getAllPostsIncludingDrafts(lang: string): Promise<BlogPost[]> {
+	try {
+		const posts = await apiFetch<Record<string, unknown>[]>(
+			`/api/blog?lang=${lang}&include_drafts=true`,
+		);
+		return posts.map((raw) => ({
+			slug: String(raw.slug ?? ""),
+			title: String(raw.title ?? raw.slug ?? ""),
+			date: String(raw.date ?? ""),
+			description: String(raw.description ?? ""),
+			tags: normalizeTags(raw.tags),
+			image: typeof raw.image === "string" ? raw.image : undefined,
+			published: raw.published !== false,
+		}));
+	} catch {
+		return [];
+	}
+}
+
 export async function getPost(
 	slug: string,
 	lang: string,

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -55,7 +55,9 @@ export async function getAllPosts(lang: string): Promise<BlogPost[]> {
 	}
 }
 
-export async function getAllPostsIncludingDrafts(lang: string): Promise<BlogPost[]> {
+export async function getAllPostsIncludingDrafts(
+	lang: string,
+): Promise<BlogPost[]> {
 	try {
 		const posts = await apiFetch<Record<string, unknown>[]>(
 			`/api/blog?lang=${lang}&include_drafts=true`,


### PR DESCRIPTION
`/[lang]/blog/preview` にドラフト・公開済みをセクション分けした一覧ページを追加。

- Drafts セクション（黄色）→ `/preview/[slug]` にリンク
- Published セクション（グレー）→ 公開 `/blog/[slug]` にリンク
- Basic auth は一覧ページも保護（regex を `/preview(\/|$)` に拡張）
- `getAllPostsIncludingDrafts()` で `include_drafts=true` API param を使用

https://claude.ai/code/session_01MTTZGTrmR3CF4TJUDQXGve

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTTZGTrmR3CF4TJUDQXGve)_