### PR TITLE
Shorten Portal API cache TTL from 1h to 5m

### DIFF
--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -23,7 +23,7 @@ type Params = AsyncLangParam & {
 	params: Promise<{ lang: "en" | "ja"; slug: string }>;
 };
 
-export const revalidate = 3600;
+export const revalidate = 300;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -5,7 +5,7 @@ import type { AsyncLangParam } from "@/types/lang-param";
 import { getAllPosts } from "@/utils/blog";
 import { getDictionary } from "../dictionaries";
 
-export const revalidate = 3600;
+export const revalidate = 300;
 
 export async function generateMetadata({
 	params,

--- a/src/app/[lang]/presentations/[slug]/page.tsx
+++ b/src/app/[lang]/presentations/[slug]/page.tsx
@@ -24,7 +24,7 @@ type Params = AsyncLangParam & {
 	params: Promise<{ lang: "en" | "ja"; slug: string }>;
 };
 
-export const revalidate = 3600;
+export const revalidate = 300;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {

--- a/src/app/[lang]/presentations/page.tsx
+++ b/src/app/[lang]/presentations/page.tsx
@@ -9,7 +9,7 @@ import { getAllPresentations } from "@/utils/presentations";
 import { getSpeakerDeckEmbed } from "@/utils/speakerdeck";
 import { getDictionary } from "../dictionaries";
 
-export const revalidate = 3600;
+export const revalidate = 300;
 
 export async function generateMetadata({
 	params,

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -23,7 +23,7 @@ async function apiFetch<T>(path: string): Promise<T> {
 	}
 	const res = await fetch(`${BLOG_API_URL}${path}`, {
 		headers: { Authorization: `Bearer ${BLOG_API_KEY}` },
-		next: { revalidate: 3600 },
+		next: { revalidate: 300 },
 	});
 	if (!res.ok) throw new Error(`Blog API ${res.status}: ${path}`);
 	return res.json() as Promise<T>;

--- a/src/utils/presentations.ts
+++ b/src/utils/presentations.ts
@@ -24,7 +24,7 @@ async function apiFetch<T>(path: string): Promise<T> {
 	}
 	const res = await fetch(`${PORTAL_API_URL}${path}`, {
 		headers: { Authorization: `Bearer ${PORTAL_API_TOKEN}` },
-		next: { revalidate: 3600 },
+		next: { revalidate: 300 },
 	});
 	if (!res.ok) throw new Error(`Portal API ${res.status}: ${path}`);
 	return res.json() as Promise<T>;

--- a/src/utils/speakerdeck.ts
+++ b/src/utils/speakerdeck.ts
@@ -12,7 +12,7 @@ export async function getSpeakerDeckEmbed(
 	try {
 		const res = await fetch(
 			`https://speakerdeck.com/oembed.json?url=${encodeURIComponent(url)}`,
-			{ next: { revalidate: 3600 } },
+			{ next: { revalidate: 300 } },
 		);
 		if (!res.ok) return null;
 		const data = await res.json();


### PR DESCRIPTION
## Summary

- Lowers ISR `revalidate` from `3600` (1h) to `300` (5m) across all Portal-API-backed content: `blog`, `blog/[slug]`, `presentations`, `presentations/[slug]`, plus the underlying `fetch()` calls in `src/utils/blog.ts` / `src/utils/presentations.ts` / `src/utils/speakerdeck.ts`.
- Motivation: while debugging why the new `/presentations` page showed no Portal API traffic after `taka-2120/portal#197` merged, we found the page had been statically built (SSG) *before* that endpoint existed, and the 1-hour ISR window meant the stale empty result — and the lack of any outbound request — could persist for up to an hour with no way to tell from the outside. A shorter TTL makes new/edited Obsidian content (and backend changes) show up much faster, and makes this kind of staleness easier to diagnose.

## Test plan

- [x] `bun run format`
- [x] `bunx tsc --noEmit`
- [x] `bun run build` — build output confirms `5m` revalidate window for `/blog` and `/presentations` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPqUQ7kK4NH8ftmryLWD49

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPqUQ7kK4NH8ftmryLWD49)_